### PR TITLE
Replace AD with CE

### DIFF
--- a/routes/hijri/archive/hijriCalendar.php
+++ b/routes/hijri/archive/hijriCalendar.php
@@ -39,8 +39,8 @@ use AlAdhanApi\Model\HijriCalendarService;
  *             },
  *             year: "2578",
  *             designation: {
- *                 abbreviated: "AD",
- *                 expanded: "Anno Domini"
+ *                 abbreviated: "CE",
+ *                 expanded: "Common Era"
  *             }
  *         },
  *         hijri: {
@@ -115,8 +115,8 @@ $app->get('/gToHCalendar/{month}/{year}', function (Request $request, Response $
  *             },
  *             year: "2578",
  *             designation: {
- *                 abbreviated: "AD",
- *                 expanded: "Anno Domini"
+ *                 abbreviated: "CE",
+ *                 expanded: "Common Era"
  *             }
  *         },
  *         hijri: {
@@ -200,8 +200,8 @@ $app->get('/hToGCalendar/{month}/{year}', function (Request $request, Response $
  *                 },
  *                 year: "2014",
  *                 designation: {
- *                     abbreviated: "AD",
- *                     expanded: "Anno Domini"
+ *                     abbreviated: "CE",
+ *                     expanded: "Common Era"
  *                 }
  *             }
  *         }
@@ -264,8 +264,8 @@ $app->get('/gToH', function (Request $request, Response $response) {
  *                 },
  *                 year: "2014",
  *                 designation: {
- *                     abbreviated: "AD",
- *                     expanded: "Anno Domini"
+ *                     abbreviated: "CE",
+ *                     expanded: "Common Era"
  *                 }
  *             }
  *         }

--- a/routes/hijri/v1/hijriCalendar.php
+++ b/routes/hijri/v1/hijriCalendar.php
@@ -40,8 +40,8 @@ $app->group('/v1', function() {
      *             },
      *             year: "2578",
      *             designation: {
-     *                 abbreviated: "AD",
-     *                 expanded: "Anno Domini"
+     *                 abbreviated: "CE",
+     *                 expanded: "Common Era"
      *             }
      *         },
      *         hijri: {
@@ -117,8 +117,8 @@ $app->group('/v1', function() {
      *             },
      *             year: "2578",
      *             designation: {
-     *                 abbreviated: "AD",
-     *                 expanded: "Anno Domini"
+     *                 abbreviated: "CE",
+     *                 expanded: "Common Era"
      *             }
      *         },
      *         hijri: {
@@ -204,8 +204,8 @@ $app->group('/v1', function() {
      *                 },
      *                 year: "2014",
      *                 designation: {
-     *                     abbreviated: "AD",
-     *                     expanded: "Anno Domini"
+     *                     abbreviated: "CE",
+     *                     expanded: "Common Era"
      *                 }
      *             }
      *         }
@@ -270,8 +270,8 @@ $app->group('/v1', function() {
      *                 },
      *                 year: "2014",
      *                 designation: {
-     *                     abbreviated: "AD",
-     *                     expanded: "Anno Domini"
+     *                     abbreviated: "CE",
+     *                     expanded: "Common Era"
      *                 }
      *             }
      *         }

--- a/routes/timings/v1/prayerTimes.php
+++ b/routes/timings/v1/prayerTimes.php
@@ -184,8 +184,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -366,8 +366,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -547,8 +547,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {

--- a/routes/timings/v1/prayerTimesCalendar.php
+++ b/routes/timings/v1/prayerTimesCalendar.php
@@ -88,8 +88,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -171,8 +171,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -347,8 +347,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -430,8 +430,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -602,8 +602,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -685,8 +685,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -851,8 +851,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -934,8 +934,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -1102,8 +1102,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -1185,8 +1185,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -1356,8 +1356,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {
@@ -1439,8 +1439,8 @@ $app->group('/v1', function() {
      *                },
      *                "year": "2018",
      *                "designation": {
-     *                    "abbreviated": "AD",
-     *                    "expanded": "Anno Domini",
+     *                    "abbreviated": "CE",
+     *                    "expanded": "Common Era",
      *                },
      *            },
      *            "hijri": {

--- a/src/AlAdhanApi/Model/HijriCalendarService.php
+++ b/src/AlAdhanApi/Model/HijriCalendarService.php
@@ -245,7 +245,7 @@ class HijriCalendarService
                     'weekday' => ['en' => date('l', strtotime($date))],
                     'month' => $monthX,
                     'year' => $dX[2],
-                    'designation' => ['abbreviated' => 'AD', 'expanded' => 'Anno Domini']
+                    'designation' => ['abbreviated' => 'AD', 'expanded' => 'Common Era']
                 ],
 
             ];
@@ -296,7 +296,7 @@ class HijriCalendarService
                     'weekday' => ['en' => date('l', strtotime($d))],
                     'month' => $month,
                     'year' => $dP[2],
-                    'designation' => ['abbreviated' => 'AD', 'expanded' => 'Anno Domini']
+                    'designation' => ['abbreviated' => 'AD', 'expanded' => 'Common Era']
                     ],
                     'hijri' =>
                     [


### PR DESCRIPTION
The term "Anno Domini" conflicts with Islamic belief, it is specifcally linked
to and comes from the Christian faith.

This API will primarily be consumed by Muslims, as such it is better to use CE
(Common Era) rather than AD.

Signed-off-by: Yasser Saleemi <yassersaleemi@gmail.com>